### PR TITLE
Use npx to get at the correct eslint executable.

### DIFF
--- a/compiler/eslint.vim
+++ b/compiler/eslint.vim
@@ -3,6 +3,6 @@ if exists("current_compiler")
 endif
 let current_compiler = "eslint"
 
-CompilerSet makeprg=./node_modules/.bin/eslint\ --no-color\ -f\ unix\ $*
+CompilerSet makeprg=npx\ --quiet\ eslint\ --no-color\ -f\ unix\ $*
 
 CompilerSet errorformat=%A%f:%l:%c:%m,%-G%.%#

--- a/compiler/eslint.vim
+++ b/compiler/eslint.vim
@@ -3,6 +3,6 @@ if exists("current_compiler")
 endif
 let current_compiler = "eslint"
 
-CompilerSet makeprg=npx\ --quiet\ eslint\ --no-color\ -f\ unix\ $*
+CompilerSet makeprg=npx\ --no-install\ --quiet\ eslint\ --no-color\ -f\ unix\ $*
 
 CompilerSet errorformat=%A%f:%l:%c:%m,%-G%.%#


### PR DESCRIPTION
I propose to use the npx runner to get at the correct eslint executable.
See:
https://medium.com/@maybekatz/introducing-npx-an-npm-package-runner-55f7d4bd282b